### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -264,6 +264,9 @@ func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, re
 	}
 
 	// Delete the existing tunnel port to update
+	if remotePort < 0 || remotePort > 65535 {
+		return fmt.Errorf("remote port %d is out of range (0-65535)", remotePort)
+	}
 	err = fwd.connection.TunnelManager.DeleteTunnelPort(ctx, fwd.connection.Tunnel, uint16(remotePort), fwd.connection.Options)
 	if err != nil {
 		return fmt.Errorf("error deleting tunnel port: %w", err)


### PR DESCRIPTION
Potential fix for [https://github.com/start-export-MA/cli/security/code-scanning/1](https://github.com/start-export-MA/cli/security/code-scanning/1)

The best way to fix this problem is to check that the `remotePort` value is within the valid range for `uint16` (i.e., `0 <= remotePort <= 65535`) before performing the type conversion. This check should be implemented directly before the conversion in `UpdatePortVisibility` in `internal/codespaces/portforwarder/port_forwarder.go`. If `remotePort` is out of range, the method should return an appropriate error rather than proceed.

No additional imports are required because `math` is unnecessary for these constants (`65535` is sufficient and clear). The check should appear immediately before the call to `DeleteTunnelPort`, on the line above the conversion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
